### PR TITLE
Add pr option

### DIFF
--- a/git-open
+++ b/git-open
@@ -30,7 +30,7 @@ if [ -n "$1" ]; then
       exit 1
     fi
   elif [ "$1" == "pr" ]; then
-    echo "my man!";
+    pr="frigg yeah"
   else
     remote="$1"
   fi
@@ -50,8 +50,6 @@ if [ -z "$2" ]; then
 else
   branch="$2"
 fi
-
-
 
 # Make # and % characters url friendly
 #   github.com/paulirish/git-open/pull/24
@@ -122,6 +120,14 @@ giturl=${giturl%\.git}
 
 if [ -n "$issue" ]; then
   giturl="${giturl}/issues/${issue}"
+elif [ -n "$pr" ]; then
+  ownerAndRepo=${giturl#https\://github.com/};
+  repo=${ownerAndRepo#*/};
+  owner=${ownerAndRepo%/$repo};
+  allPrsUrl="https://api.github.com/repos/"$ownerAndRepo"/pulls?head="$owner":"$branch;
+  unparsedPrUrl=$(curl -s $allPrsUrl | grep -m 1 html_url 2> /dev/null);
+  unparsedPrUrl=${unparsedPrUrl#*\"\: \"};
+  giturl=${unparsedPrUrl%\"\,};
 elif [ -n "$branch" ]; then
   giturl="${giturl}/${providerUrlDifference}/${branch}"
 fi

--- a/git-open
+++ b/git-open
@@ -6,6 +6,10 @@
 # git open
 # git open [remote] [branch]
 
+# import pr-utils from git-open's directory
+SOURCE_DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$SOURCE_DIR" ]]; then SOURCE_DIR="$PWD"; fi
+. "$SOURCE_DIR/pr-utils"
 
 # are we in a git repo?
 git rev-parse --is-inside-work-tree &>/dev/null

--- a/git-open
+++ b/git-open
@@ -23,23 +23,34 @@ fi
 # assume origin if not provided
 # fallback to upstream if neither is present.
 remote="origin"
-if [ "$1" == "pr" ]; then
-  pr="true"
-  shift;
-fi
 if [ -n "$1" ]; then
-  if [ "$1" == "issue" ]; then
-    currentBranch=$(git symbolic-ref -q --short HEAD)
-    regex='^issue'
-    if [[ $currentBranch =~ $regex ]]; then
-      issue=${currentBranch#*#}
-    else
-      echo "'git open issue' expect branch naming to be issues/#123" 1>&2
-      exit 1
-    fi
-  else
-    remote="$1"
-  fi
+  case "$1" in
+    "pr")
+      pr="self"
+      shift;
+      if [ "$1" == "parent" ]; then
+        pr="parent"
+        shift;
+      fi
+      if [ -n "$1" ]; then
+        remote="$1"
+      fi
+      ;;
+    "issue")
+      echo issue
+      currentBranch=$(git symbolic-ref -q --short HEAD)
+      regex='^issue'
+      if [[ $currentBranch =~ $regex ]]; then
+        issue=${currentBranch#*#}
+      else
+        echo "'git open issue' expect branch naming to be issues/#123" 1>&2
+        exit 1
+      fi
+      ;;
+    *)
+      remote="$1"
+      ;;
+  esac
 fi
 
 remote_url="remote.${remote}.url"

--- a/git-open
+++ b/git-open
@@ -51,6 +51,8 @@ else
   branch="$2"
 fi
 
+
+
 # Make # and % characters url friendly
 #   github.com/paulirish/git-open/pull/24
 branch=${branch//%/%25} && branch=${branch//#/%23}

--- a/git-open
+++ b/git-open
@@ -127,7 +127,10 @@ elif [ -n "$pr" ]; then
   allPrsUrl="https://api.github.com/repos/"$ownerAndRepo"/pulls?head="$owner":"$branch;
   unparsedPrUrl=$(curl -s $allPrsUrl | grep -m 1 html_url 2> /dev/null);
   unparsedPrUrl=${unparsedPrUrl#*\"\: \"};
-  giturl=${unparsedPrUrl%\"\,};
+  prUrl=${unparsedPrUrl%\"\,};
+  if [ -n "$prUrl" ]; then
+    giturl=$prUrl
+  fi
 elif [ -n "$branch" ]; then
   giturl="${giturl}/${providerUrlDifference}/${branch}"
 fi

--- a/git-open
+++ b/git-open
@@ -120,16 +120,30 @@ else
 fi
 giturl=${giturl%\.git}
 
+# Gets url to all PRs for branch
+function getAllPrsUrl {
+  local giturl="$1";
+  local ownerAndRepo=${giturl#https\://github.com/};
+  local repo=${ownerAndRepo#*/};
+  local owner=${ownerAndRepo%/$repo};
+  local allPrsUrl="https://api.github.com/repos/"$ownerAndRepo"/pulls?head="$owner":"$branch;
+  echo $allPrsUrl;
+}
+
+# Gets most recent PR from all PRs for branch
+function getPrUrl {
+  local allPrsUrl="$1"
+  local unparsedPrUrl=$(curl -s $allPrsUrl | grep -m 1 html_url 2> /dev/null);
+  local unparsedPrUrl=${unparsedPrUrl#*\"\: \"};
+  local prUrl=${unparsedPrUrl%\"\,};
+  echo $prUrl
+}
+
 if [ -n "$issue" ]; then
   giturl="${giturl}/issues/${issue}"
 elif [ -n "$pr" ]; then
-  ownerAndRepo=${giturl#https\://github.com/};
-  repo=${ownerAndRepo#*/};
-  owner=${ownerAndRepo%/$repo};
-  allPrsUrl="https://api.github.com/repos/"$ownerAndRepo"/pulls?head="$owner":"$branch;
-  unparsedPrUrl=$(curl -s $allPrsUrl | grep -m 1 html_url 2> /dev/null);
-  unparsedPrUrl=${unparsedPrUrl#*\"\: \"};
-  prUrl=${unparsedPrUrl%\"\,};
+  allPrsUrl=$(getAllPrsUrl $giturl)
+  prUrl=$(getPrUrl $allPrsUrl)
   if [ -n "$prUrl" ]; then
     giturl=$prUrl
   fi

--- a/git-open
+++ b/git-open
@@ -146,6 +146,9 @@ elif [ -n "$pr" ]; then
   prUrl=$(getPrUrl $allPrsUrl)
   if [ -n "$prUrl" ]; then
     giturl=$prUrl
+  else
+    echo "No pull requests for $branch" 1>&2
+    exit 1
   fi
 elif [ -n "$branch" ]; then
   giturl="${giturl}/${providerUrlDifference}/${branch}"

--- a/git-open
+++ b/git-open
@@ -135,25 +135,6 @@ else
 fi
 giturl=${giturl%\.git}
 
-# Gets url to all PRs for branch
-function getAllPrsUrl {
-  local giturl="$1";
-  # assumes $giturl is of the form .*/user/repo
-  local owner=`expr "$giturl" : '.*/\(.*\)/.*$'`
-  local repo=`expr "$giturl" : '.*/\(.*\)$'`
-  # github-only solution
-  local allPrsUrl="https://api.github.com/repos/"$owner"/"$repo"/pulls?head="$owner":"$branch
-  echo $allPrsUrl;
-}
-
-# Gets most recent PR from all PRs for branch
-function getPrUrl {
-  local allPrsUrl="$1"
-  local unparsedPrUrl=$(curl -s $allPrsUrl | grep -m 1 html_url 2> /dev/null)
-  local prUrl=`expr "$unparsedPrUrl" : '.*\"\(.*\)\",$'`
-  echo $prUrl
-}
-
 if [ -n "$issue" ]; then
   giturl="${giturl}/issues/${issue}"
 elif [ -n "$pr" ]; then

--- a/git-open
+++ b/git-open
@@ -29,6 +29,8 @@ if [ -n "$1" ]; then
       echo "'git open issue' expect branch naming to be issues/#123" 1>&2
       exit 1
     fi
+  elif [ "$1" == "pr" ]; then
+    echo "my man!";
   else
     remote="$1"
   fi

--- a/git-open
+++ b/git-open
@@ -19,6 +19,10 @@ fi
 # assume origin if not provided
 # fallback to upstream if neither is present.
 remote="origin"
+if [ "$1" == "pr" ]; then
+  pr="true"
+  shift;
+fi
 if [ -n "$1" ]; then
   if [ "$1" == "issue" ]; then
     currentBranch=$(git symbolic-ref -q --short HEAD)
@@ -29,8 +33,6 @@ if [ -n "$1" ]; then
       echo "'git open issue' expect branch naming to be issues/#123" 1>&2
       exit 1
     fi
-  elif [ "$1" == "pr" ]; then
-    pr="frigg yeah"
   else
     remote="$1"
   fi

--- a/git-open
+++ b/git-open
@@ -121,13 +121,13 @@ giturl=${giturl%\.git}
 if [ -n "$issue" ]; then
   giturl="${giturl}/issues/${issue}"
 elif [ -n "$pr" ]; then
-  ownerAndRepo=${giturl#https\://github.com/};
-  repo=${ownerAndRepo#*/};
-  owner=${ownerAndRepo%/$repo};
-  allPrsUrl="https://api.github.com/repos/"$ownerAndRepo"/pulls?head="$owner":"$branch;
-  unparsedPrUrl=$(curl -s $allPrsUrl | grep -m 1 html_url 2> /dev/null);
-  unparsedPrUrl=${unparsedPrUrl#*\"\: \"};
-  prUrl=${unparsedPrUrl%\"\,};
+  # assumes $giturl is of the form .*/user/repo
+  owner=`expr "$giturl" : '.*/\(.*\)/.*$'`
+  repo=`expr "$giturl" : '.*/\(.*\)$'`
+  # github-only solution
+  allPrsUrl="https://api.github.com/repos/"$owner"/"$repo"/pulls?head="$owner":"$branch
+  unparsedPrUrl=$(curl -s $allPrsUrl | grep -m 1 html_url 2> /dev/null)
+  prUrl=`expr "$unparsedPrUrl" : '.*\"\(.*\)\",$'`
   if [ -n "$prUrl" ]; then
     giturl=$prUrl
   fi

--- a/pr-utils
+++ b/pr-utils
@@ -1,0 +1,18 @@
+# Gets url to all PRs for branch
+function getAllPrsUrl {
+  local giturl="$1";
+  # assumes $giturl is of the form .*/user/repo
+  local owner=`expr "$giturl" : '.*/\(.*\)/.*$'`
+  local repo=`expr "$giturl" : '.*/\(.*\)$'`
+  # github-only solution
+  local allPrsUrl="https://api.github.com/repos/"$owner"/"$repo"/pulls?head="$owner":"$branch
+  echo $allPrsUrl;
+}
+
+# Gets most recent PR from all PRs for branch
+function getPrUrl {
+  local allPrsUrl="$1"
+  local unparsedPrUrl=$(curl -s $allPrsUrl | grep -m 1 html_url 2> /dev/null)
+  local prUrl=`expr "$unparsedPrUrl" : '.*\"\(.*\)\",$'`
+  echo $prUrl
+}


### PR DESCRIPTION
Makes `git open pr` open the most recent _open_ PR for the current branch.

Cases to consider:
- [x] PRs on same repo
- [ ] PRs across forks
- [ ] PRs in private repos 
